### PR TITLE
Update instructions for installing perlcritic

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This linter plugin for [SublimeLinter](https://github.com/SublimeLinter/SublimeL
 SublimeLinter 3 must be installed in order to use this plugin. If SublimeLinter 3 is not installed, please follow the instructions [here](http://sublimelinter.readthedocs.org/en/latest/installation.html).
 
 ### Linter installation
-Before installing this plugin, you must ensure that `perlcritic` is installed on your system. To install `perl`, type `cpanm pelcritic`.
+Before installing this plugin, you must ensure that `perlcritic` is installed on your system. To install `perl`, type `cpanm Perl::Critic`.
 
 ### Plugin installation
 Please use [Package Control](https://sublime.wbond.net/installation) to install the linter plugin. This will ensure that the plugin will be updated when new versions are available. If you want to install from source so you can modify the source code, you probably know what you are doing so we won't cover that here.
@@ -16,7 +16,7 @@ To install via Package Control, do the following:
 
 1. Within Sublime Text, bring up the [Command Palette](http://docs.sublimetext.info/en/sublime-text-3/extensibility/command_palette.html)  and type `install`. Among the commands you should see `Package Control: Install Package`. If that command is not highlighted, use the keyboard or mouse to select it. There will be a pause of a few seconds while Package Control fetches the list of available plugins.
 
-2. When the plugin list appears, type `pelcritic`. Among the entries you should see `SublimeLinter-pelcritic`. If that entry is not highlighted, use the keyboard or mouse to select it.
+2. When the plugin list appears, type `perlcritic`. Among the entries you should see `SublimeLinter-perlcritic`. If that entry is not highlighted, use the keyboard or mouse to select it.
 
 ## Settings
 For general information on how SublimeLinter works with settings, please see [Settings](http://sublimelinter.readthedocs.org/en/latest/settings.html). For information on generic linter settings, please see [Linter Settings](http://sublimelinter.readthedocs.org/en/latest/linter_settings.html).


### PR DESCRIPTION
The perlcritic command is installed by the Perl::Critic module.

(Also fixes a couple typos)
