### PR TITLE
Compatibility with Sublime Linter 4

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -11,13 +11,88 @@
 """This module exports the PerlCritic linter class."""
 
 import os
-from SublimeLinter.lint import Linter, util
+from SublimeLinter.lint import Linter
 
+
+#-----------------------------------------------------------------------------
+#
+# sl3_util_climb & sl3_util_find_file
+#
+#   Sublime Linter 4 retired util.climb and util.find_file and by doing so
+#   this linter was rendered unusable.  We are making copies of the retired
+#   code here to still be able to find configuration files for perlcritic
+#   looking upwards among directories in the project.
+#
+
+def sl3_util_climb(start_dir, limit=None):
+    """
+    Generate directories, starting from start_dir.
+
+    If limit is None, stop at the root directory.
+    Otherwise return a maximum of limit directories.
+    """
+    right = True
+
+    while right and (limit is None or limit > 0):
+        yield start_dir
+        start_dir, right = os.path.split(start_dir)
+
+        if limit is not None:
+            limit -= 1
+
+
+def sl3_util_find_file(start_dir, name, parent=False, limit=None, aux_dirs=[]):
+    """
+    Find the given file by searching up the file hierarchy from start_dir.
+
+    If the file is found and parent is False, returns the path to the file.
+    If parent is True the path to the file's parent directory is returned.
+
+    If limit is None, the search will continue up to the root directory.
+    Otherwise a maximum of limit directories will be checked.
+
+    If aux_dirs is not empty and the file hierarchy search failed,
+    those directories are also checked.
+    """
+    for d in sl3_util_climb(start_dir, limit=limit):
+        target = os.path.join(d, name)
+
+        if os.path.exists(target):
+            if parent:
+                return d
+
+            return target
+
+    for d in aux_dirs:
+        d = os.path.expanduser(d)
+        target = os.path.join(d, name)
+
+        if os.path.exists(target):
+            if parent:
+                return d
+
+            return target
+
+#-----------------------------------------------------------------------------
 
 class PerlCritic(Linter):
 
     """Provides an interface to perlcritic."""
 
     syntax = ('modernperl', 'perl')
+    executable = 'perlcritic'
     regex = r'\[.+\] (?P<message>.+?) at line (?P<line>\d+), column (?P<col>\d+).+?'
-    cmd = [ 'perlcritic', '--verbose', '8']
+
+    def cmd(self):
+        """Return a tuple with the command line to execute."""
+
+        command = [self.executable, '--verbose', '8']
+
+        config = sl3_util_find_file(
+            os.path.dirname(self.filename), '.perlcriticrc'
+        )
+
+        if config:
+            command += ['-p', config]
+
+        return command

--- a/linter.py
+++ b/linter.py
@@ -19,18 +19,5 @@ class PerlCritic(Linter):
     """Provides an interface to perlcritic."""
 
     syntax = ('modernperl', 'perl')
-    executable = 'perlcritic'
     regex = r'\[.+\] (?P<message>.+?) at line (?P<line>\d+), column (?P<col>\d+).+?'
-
-    def cmd(self):
-        """Return a tuple with the command line to execute."""
-
-        command = [self.executable_path, '--verbose', '8']
-
-        config = util.find_file(
-            os.path.dirname(self.filename), '.perlcriticrc')
-
-        if config:
-            command += ['-p', config]
-
-        return command
+    cmd = [ 'perlcritic', '--verbose', '8']


### PR DESCRIPTION
In Sublime Linter 4 [they removed `util.find_file`](https://github.com/SublimeLinter/SublimeLinter/commit/97f027fb58997b25105184c3ba0a6528ad5a091c#diff-6e6fb941c4b3a249f53ac9a3ef3da85d) upon which SL-perlctitic relied.  This fix deals with that, at least in the basic (presumably the most common) case, without the need of "climbling" directories as `util.find_file` did.