### PR TITLE
Syntax deprecated in favor to 'selector'

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -79,9 +79,12 @@ class PerlCritic(Linter):
 
     """Provides an interface to perlcritic."""
 
-    syntax = ('modernperl', 'perl')
     executable = 'perlcritic'
     regex = r'\[.+\] (?P<message>.+?) at line (?P<line>\d+), column (?P<col>\d+).+?'
+
+    defaults = {
+        'selector': 'source.modernperl, source.perl'
+    }
 
     def cmd(self):
         """Return a tuple with the command line to execute."""


### PR DESCRIPTION
SublimeLinter: WARNING: perlcritic: Defining 'cls.syntax' has been deprecated. Use http://www.sublimelinter.com/en/stable/linter_settings.html#selector