### PR TITLE
Remove deprecated `.exectuable` attr

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -79,7 +79,6 @@ class PerlCritic(Linter):
 
     """Provides an interface to perlcritic."""
 
-    executable = 'perlcritic'
     regex = r'\[.+\] (?P<message>.+?) at line (?P<line>\d+), column (?P<col>\d+).+?'
 
     defaults = {
@@ -89,7 +88,7 @@ class PerlCritic(Linter):
     def cmd(self):
         """Return a tuple with the command line to execute."""
 
-        command = [self.executable, '--verbose', '8']
+        command = ['perlcritic', '--verbose', '8']
 
         config = sl3_util_find_file(
             os.path.dirname(self.filename), '.perlcriticrc'


### PR DESCRIPTION
Fixes warning from `SublimeLinter`: `SublimeLinter: WARNING: perlcritic: Defining 'cls.executable' has no effect. Please cleanup and remove this setting.`